### PR TITLE
Fix typography when text is empty 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+#macOS
+.DS_Store
+
+# Xcode
+xcuserdata/
+Build/
+
+# Cocoapods
+Pods
+*.xcworkspace
+
+# Bundler
+vendor
+.bundle
+
+#CocoaPods Keys
+.env

--- a/UILabel_Typography_Extensions/LineHeightViewController.swift
+++ b/UILabel_Typography_Extensions/LineHeightViewController.swift
@@ -20,7 +20,6 @@ class LineHeightViewController: UIViewController {
 		.views(
 			
 			UILabel()
-				.with(text: text)
 				.with {
 					$0.textColor = .label
 					$0.font = UIFont.newYork(ofSize: 1024 / 26.0 / 2.0)
@@ -29,7 +28,8 @@ class LineHeightViewController: UIViewController {
 					$0.showGrid = true
 					$0.underline = .single
 					self.label = $0
-				},
+				}
+                .with(text: text),
 			
 			UISlider()
 				.with {

--- a/UILabel_Typography_Extensions/Typography/UILabel+Observer.swift
+++ b/UILabel_Typography_Extensions/Typography/UILabel+Observer.swift
@@ -44,7 +44,7 @@ extension UILabel {
 		}
 	}
 	
-	func observeIfNeeded() {
+    func observeTextChange(onChange completion: @escaping ()->()) {
 		guard observer == nil else {
 			return
 		}
@@ -52,11 +52,7 @@ extension UILabel {
 		observer = TextObserver(
 			for: self,
 			keyPath: \.text,
-			onChange: { [weak self] _ in
-				if let attributedText = self?.attributedText {
-					self?.attributedText = attributedText
-				}
-			}
+			onChange:  { _ in completion() }
 		)
 	}
 }


### PR DESCRIPTION
# What was fixed
- Add gitignore
- In `LineHeightViewController` move text after typography changes to see if the issue is fixed.
- Make observing a higher order function instead of using hardcoded closure.
- Add static dictionary where key is the UILabel and value are the attributes for this label. This is a hack to have a stored property in extension without using objc.
- Whenever attribute is fetched via getter, check if it should use the static dictionary value. If so, swap the values in label and remove the values from the dictionary. Also fix the text alignment that would otherwise be reset.
- Whenever attribute is added to empty string, store it in the static dictionary for a specific label.
- Whenever attribute is removed, remove it in the dictionary as well.
- Make closure that is triggered on text change do two things
  - a) _ = self.attributedText -> This code should not do anything as it's only getter from the UIKit, but internal implementation of the UIKit has side-effects that are actually fixing the typography problems! It does not have to be a setter as in previous implementation.
  - b) _ = self.attributes -> This code is also a getter, but this logic needs to be triggered each time text changes to swap values if previous static dictionary had values (hence, previous value had to be empty string).
NOTE: Code from line "a" is not necessary, as code from line "b" contains code from line "a" anyway. It's added here for the brevity of the iOS Framework side effects

# Tests
Following changes for UILabel were tested manually. **All tested passed**
```
    // lineHeight = 50 -> "BBB"
    // lineHeight = 50 -> "BBB" -> "CCC"
    // lineHeight = 50 -> "" -> "BBB"
    // lineHeight = 50 -> "BBB" -> ""-> "CCC"
    // lineHeight = 50 -> "BBB" -> ""-> "" -> "CCC"
    // lineHeight = 50 -> "" -> ""-> "" -> "AAA"
    // lineHeight = 50 -> "" -> "" -> lineHeight = nil -> "" -> "BBB"
    // lineHeight = 50 -> "BBB" -> "" -> lineHeight = nil -> "" -> "CCC"
    // lineHeight = 50 -> "" -> lineHeight = nil -> lineHeight = 50 -> "BBB"
    // lineHeight = 50 -> "" -> lineHeight = nil -> "BBB"


    // "" -> lineHeight = 50 -> "BBB"
    // "" -> lineHeight = 50 -> "BBB" -> "CCC"
    // "" -> lineHeight = 50 -> "" -> "BBB" 
    // "" -> lineHeight = 50 -> "BBB" -> ""-> "CCC"
    // "" -> lineHeight = 50 -> "BBB" -> ""-> "" -> "CCC"
    // "" -> lineHeight = 50 -> "" -> ""-> "" -> "AAA"
    // "" -> lineHeight = 50 -> "" -> lineHeight = nil -> "BBB"
    // "" -> lineHeight = 50 -> "" -> lineHeight = nil -> lineHeight = 50 -> "BBB"
    // "" -> lineHeight = 50 -> "" -> "" -> lineHeight = nil -> "" -> "BBB"
    // "" -> lineHeight = 50 -> "BBB" -> "" -> lineHeight = nil -> "" -> "CCC"

    // "AAA" -> lineHeight = 50 -> "BBB"
    // "AAA" -> lineHeight = 50 -> "BBB" -> "CCC"
    // "AAA" -> lineHeight = 50 -> "" -> "BBB"
    // "AAA" -> lineHeight = 50 -> "BBB" -> ""-> "CCC"
    // "AAA" -> lineHeight = 50 -> "BBB" -> ""-> "" -> "CCC"
    // "AAA" -> lineHeight = 50 -> "" -> ""-> "" -> "AAA"
    // "AAA" -> lineHeight = 50 -> "" -> lineHeight = nil -> "BBB"
    // "AAA" -> lineHeight = 50 -> "" -> lineHeight = nil -> lineHeight = 50 -> "BBB"
    // "AAA" -> lineHeight = 50 -> "BBB" -> "" -> lineHeight = nil -> "" -> "CCC"
    // "AAA" -> lineHeight = 50 -> "" -> "" -> lineHeight = nil -> "" -> "BBB"
```

_Issue:_  https://github.com/Geri-Borbas/iOS.Blog.UILabel_Typography_Extensions/issues/1
